### PR TITLE
feat: add tag filtering

### DIFF
--- a/Baseball/Baseball.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Baseball/Baseball.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "realm-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-core.git",
+      "state" : {
+        "revision" : "c2552e1d36867cb42b28130e894a81fc17081062",
+        "version" : "14.12.0"
+      }
+    },
+    {
+      "identity" : "realm-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-swift.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "7ffcc1165fe335b793f59c5a4ff0d472fcc1625a"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Baseball/Baseball/Source/Model/Ticket.swift
+++ b/Baseball/Baseball/Source/Model/Ticket.swift
@@ -18,6 +18,7 @@ import RealmSwift
 /// - ourTeamScore: 우리 팀 점수
 /// - opponentTeamScore: 상대 팀 점수
 /// - feeling: 기분
+/// - result: 경기 결과 (승요/패요/동요 구분)
 /// - title: 관람 후기 제목
 /// - review: 관람 후기
 ///

--- a/Baseball/Baseball/Source/Model/Ticket.swift
+++ b/Baseball/Baseball/Source/Model/Ticket.swift
@@ -31,6 +31,7 @@ class Ticket: Object {
     @Persisted var ourTeamScore: Int
     @Persisted var opponentTeamScore: Int
     @Persisted var feeling: String
+    @Persisted var result: String
     @Persisted var title: String
     @Persisted var review: String
     
@@ -38,7 +39,7 @@ class Ticket: Object {
         return ourTeamScore > opponentTeamScore
     }
     
-    convenience init(date: String, place: String, ourTeam: String, opponentTeam: String, ourTeamScore: Int, opponentTeamScore: Int, feeling: String, title: String, review: String) {
+    convenience init(date: String, place: String, ourTeam: String, opponentTeam: String, ourTeamScore: Int, opponentTeamScore: Int, feeling: String, result: String, title: String, review: String) {
         self.init()
         self.date = date
         self.place = place
@@ -47,6 +48,7 @@ class Ticket: Object {
         self.ourTeamScore = ourTeamScore
         self.opponentTeamScore = opponentTeamScore
         self.feeling = feeling
+        self.result = result
         self.title = title
         self.review = review
     }

--- a/Baseball/Baseball/Source/Utils/Manager/RealmManager.swift
+++ b/Baseball/Baseball/Source/Utils/Manager/RealmManager.swift
@@ -34,4 +34,9 @@ class RealmManager {
         let tickets = realm.objects(Ticket.self)
         return Array(tickets)
     }
+    
+    func filterTicketData(item: String, condition: String) -> [Ticket] {
+        let filteredTickets = realm.objects(Ticket.self).filter("\(item) == %@", condition)
+        return Array(filteredTickets)
+    }
 }

--- a/Baseball/Baseball/Source/View/MainView.swift
+++ b/Baseball/Baseball/Source/View/MainView.swift
@@ -307,7 +307,7 @@ extension MainView {
                         LinearGradient(gradient: Gradient(colors: [Color.colorTeam(data.ourTeam), Color.colorTeam(data.opponentTeam)]), startPoint: /*@START_MENU_TOKEN@*/.leading/*@END_MENU_TOKEN@*/, endPoint: /*@START_MENU_TOKEN@*/.trailing/*@END_MENU_TOKEN@*/)
                     }
                     .clipShape(TicketShape(cornerRadius: 8, cutRadius: 40))
-                    .modifier(TicketStroke(cornerRadius: 8, cutRadius: 40))
+                    .modifier(TicketStroke(cornerRadius: 8, cutRadius: 40, isShare: false))
                     .padding(.horizontal, 9)
                     .padding(.bottom, 16)
                     .matchedGeometryEffect(id: data.id, in: animation)

--- a/Baseball/Baseball/Source/View/MainView.swift
+++ b/Baseball/Baseball/Source/View/MainView.swift
@@ -11,6 +11,8 @@ struct MainView: View {
     @StateObject private var viewModel = MainViewModel()
     @Namespace var animation
     
+    @State private var isFilteredByResult = false
+    @State private var isFilteredByTeam = false
     @State private var moveInputTicketView = false
     @State private var moveTicketView = false
     @State private var selectedData: Ticket?
@@ -221,7 +223,13 @@ extension MainView {
     private var ticketTags: some View {
         HStack {
             Button {
-                // action
+                isFilteredByResult.toggle()
+                if isFilteredByResult {
+                    viewModel.filteTicketData(item: "result", condition: "승요")
+                }
+                if isFilteredByTeam {
+                    isFilteredByTeam.toggle()
+                }
             } label: {
                 Text("승요")
                     .padding(.horizontal, 20)
@@ -231,11 +239,18 @@ extension MainView {
             .background {
                 RoundedRectangle(cornerRadius: 15.0)
                     .fill(.clear)
-                    .stroke(viewModel.ticketData.isEmpty ? .caption : .stroke)
+                    .stroke(viewModel.ticketData.isEmpty || !isFilteredByResult ? .caption : .stroke)
             }
+            .foregroundStyle(viewModel.ticketData.isEmpty || !isFilteredByResult ? .caption : .text)
             
             Button {
-                // action
+                isFilteredByTeam.toggle()
+                if isFilteredByTeam {
+                    viewModel.filteTicketData(item: "ourTeam", condition: UserDefaults.standard.string(forKey: "myTeam")!)
+                }
+                if isFilteredByResult {
+                    isFilteredByResult.toggle()
+                }
             } label: {
                 Text("우리팀")
                     .padding(.horizontal, 20)
@@ -245,10 +260,10 @@ extension MainView {
             .background {
                 RoundedRectangle(cornerRadius: 15.0)
                     .fill(.clear)
-                    .stroke(viewModel.ticketData.isEmpty ? .caption : .stroke)
+                    .stroke(viewModel.ticketData.isEmpty || !isFilteredByTeam ? .caption : .stroke)
             }
+            .foregroundStyle(viewModel.ticketData.isEmpty || !isFilteredByTeam ? .caption : .text)
         }
-        .foregroundStyle(viewModel.ticketData.isEmpty ? .caption : .text)
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 12)
         .padding(.bottom, 16)
@@ -260,7 +275,7 @@ extension MainView {
 extension MainView {
     private var ticketPreviewStack: some View {
         LazyVStack {
-            ForEach(viewModel.ticketData, id: \.id) { data in
+            ForEach(isFilteredByResult || isFilteredByTeam ? viewModel.filteredData : viewModel.ticketData, id: \.id) { data in
                 Button {
                     withAnimation(.easeInOut(duration: 0.5)) {
                         moveTicketView = true

--- a/Baseball/Baseball/Source/View/MainView.swift
+++ b/Baseball/Baseball/Source/View/MainView.swift
@@ -223,7 +223,9 @@ extension MainView {
     private var ticketTags: some View {
         HStack {
             Button {
-                isFilteredByResult.toggle()
+                withAnimation(.easeInOut(duration: 0.5)) {
+                    isFilteredByResult.toggle()
+                }
                 if isFilteredByResult {
                     viewModel.filteTicketData(item: "result", condition: "승요")
                 }
@@ -244,7 +246,9 @@ extension MainView {
             .foregroundStyle(viewModel.ticketData.isEmpty || !isFilteredByResult ? .caption : .text)
             
             Button {
-                isFilteredByTeam.toggle()
+                withAnimation(.easeInOut(duration: 0.5)) {
+                    isFilteredByTeam.toggle()
+                }
                 if isFilteredByTeam {
                     viewModel.filteTicketData(item: "ourTeam", condition: UserDefaults.standard.string(forKey: "myTeam")!)
                 }

--- a/Baseball/Baseball/Source/View/Ticket/TicketView.swift
+++ b/Baseball/Baseball/Source/View/Ticket/TicketView.swift
@@ -154,7 +154,7 @@ extension TicketView {
                 team: data.opponentTeam,
                 image: "envelope.open",
                 infoTitle: "Lucky",
-                info: "승요"
+                info: data.result
             )
             Spacer()
         }

--- a/Baseball/Baseball/Source/ViewModel/InputTicketViewModel.swift
+++ b/Baseball/Baseball/Source/ViewModel/InputTicketViewModel.swift
@@ -19,7 +19,7 @@ class InputTicketViewModel: ObservableObject {
     @Published var currentPage = 0
     @Published var date = Date()
     @Published var place = ""
-    @Published var ourTeam = "삼성 라이온즈"
+    @Published var ourTeam = UserDefaults.standard.string(forKey: "myTeam")!
     @Published var opponentTeam = ""
     @Published var ourTeamScore = ""
     @Published var opponentTeamScore = ""
@@ -42,6 +42,16 @@ class InputTicketViewModel: ObservableObject {
         ("😆", "신나요")
     ]
     
+    func setTodayResult() -> String {
+        if Int(ourTeamScore) ?? 0 > Int(opponentTeamScore) ?? 0 {
+            return "승요"
+        } else if Int(ourTeamScore) ?? 0 < Int(opponentTeamScore) ?? 0 {
+            return "패요"
+        } else {
+            return "동요"
+        }
+    }
+    
     func saveData() {
         RealmManager.shared.saveTicketData(
             Ticket(
@@ -52,6 +62,7 @@ class InputTicketViewModel: ObservableObject {
                 ourTeamScore: Int(ourTeamScore) ?? 0,
                 opponentTeamScore: Int(opponentTeamScore) ?? 0,
                 feeling: currentEmotion, 
+                result: setTodayResult(),
                 title: todayTitle,
                 review: todayComment
             )

--- a/Baseball/Baseball/Source/ViewModel/InputTicketViewModel.swift
+++ b/Baseball/Baseball/Source/ViewModel/InputTicketViewModel.swift
@@ -42,7 +42,7 @@ class InputTicketViewModel: ObservableObject {
         ("😆", "신나요")
     ]
     
-    func setTodayResult() -> String {
+    private func setTodayResult() -> String {
         if Int(ourTeamScore) ?? 0 > Int(opponentTeamScore) ?? 0 {
             return "승요"
         } else if Int(ourTeamScore) ?? 0 < Int(opponentTeamScore) ?? 0 {

--- a/Baseball/Baseball/Source/ViewModel/MainViewModel.swift
+++ b/Baseball/Baseball/Source/ViewModel/MainViewModel.swift
@@ -9,8 +9,13 @@ import Foundation
 
 class MainViewModel: ObservableObject {
     @Published var ticketData = [Ticket]()
+    @Published var filteredData = [Ticket]()
     
     func loadTicketData() {
         ticketData = RealmManager.shared.loadTicketData()
+    }
+    
+    func filteTicketData(item: String, condition: String) {
+        filteredData = RealmManager.shared.filterTicketData(item: item, condition: condition)
     }
 }


### PR DESCRIPTION
## 📌 Summary
resolved #28 

<br>

## ✨ Description
<!-- 작업 내용 -->

1. `Ticket` 데이터 모델을 수정하였습니다.
   - 혹시 나중의 이스터에그 활용이나 기능 추가를 고려하여, 감정 항목은 그대로 유지하였습니다.
```swift
class Ticket: Object {
    @Persisted var id = UUID()
    @Persisted var date: String
    @Persisted var place: String
    @Persisted var ourTeam: String
    @Persisted var opponentTeam: String
    @Persisted var ourTeamScore: Int
    @Persisted var opponentTeamScore: Int
    @Persisted var feeling: String
    @Persisted var result: String
    @Persisted var title: String
    @Persisted var review: String
    
    var winner: Bool {
        return ourTeamScore > opponentTeamScore
    }
    
    convenience init(date: String, place: String, ourTeam: String, opponentTeam: String, ourTeamScore: Int, opponentTeamScore: Int, feeling: String, result: String, title: String, review: String) {
        self.init()
        self.date = date
        self.place = place
        self.ourTeam = ourTeam
        self.opponentTeam = opponentTeam
        self.ourTeamScore = ourTeamScore
        self.opponentTeamScore = opponentTeamScore
        self.feeling = feeling
        self.result = result
        self.title = title
        self.review = review
    }
}
```
2. `InputTicketViewModel`에 `setTodayResult()` 함수를 추가하여 팀 성적에 따라 result 값을 반환하도록 하였습니다.
```swift
func setTodayResult() -> String {
        if Int(ourTeamScore) ?? 0 > Int(opponentTeamScore) ?? 0 {
            return "승요"
        } else if Int(ourTeamScore) ?? 0 < Int(opponentTeamScore) ?? 0 {
            return "패요"
        } else {
            return "동요"
        }
    }
    
    func saveData() {
        RealmManager.shared.saveTicketData(
            Ticket(
                date: date.dateToString(), 
                place: place,
                ourTeam: ourTeam,
                opponentTeam: opponentTeam,
                ourTeamScore: Int(ourTeamScore) ?? 0,
                opponentTeamScore: Int(opponentTeamScore) ?? 0,
                feeling: currentEmotion, 
                result: setTodayResult(),
                title: todayTitle,
                review: todayComment
            )
        )
    }
```
3. `RealmManager`에 `filterTicketData(item:condition:)` 함수를 추가하여 태그 버튼에 따라 데이터 필터링이 이루어질 수 있도록 하였습니다.
```swift
func filterTicketData(item: String, condition: String) -> [Ticket] {
        let filteredTickets = realm.objects(Ticket.self).filter("\(item) == %@", condition)
        return Array(filteredTickets)
    }
```
4. `MainView`에 `isFilteredByResult`와 `isFilteredByTeam` 변수를 추가하여, 필터링 여부를 관리하고 필터링 여부에 따라 필터링 조건에 맞는 데이터를 보여줄 수 있도록 하였습니다.

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/9594ff16-ebbe-4b85-8435-0ba2f2d316c2" width ="250">|

<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
애니메이션을 추가하여 위 GIF 파일보다 더 자연스럽게 화면 전환이 이루어지도록 하였습니다:)
```
